### PR TITLE
Add tests to check that cookiecutter is generated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
   - conda config --add channels mosdef
   - conda create -n test-environment python=$PYTHON_VERSION --file requirements-dev.txt
   - source activate test-environment
-  - pip install tox
   - pip install -e .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: generic
+
+sudo: false
+
+matrix:
+    include:
+        - {os: linux, env: PYTHON_VERSION=3.6 }
+        - {os: linux, env: PYTHON_VERSION=3.7 }
+        - {os: osx, env: PYTHON_VERSION=3.6 }
+        - {os: osx, env: PYTHON_VERSION=3.7 }
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
+  - source devtools/travis-ci/install.sh
+  - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels omnia
+  - conda config --add channels conda-forge
+  - conda config --add channels mosdef
+  - conda create -n test-environment python=$PYTHON_VERSION --file requirements-dev.txt
+  - source activate test-environment
+  - pip install tox
+  - pip install -e .
+
+script:
+  - python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
   - pip install -e .
 
 script:
-  - python tests/*
+  - pytest tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
   - pip install -e .
 
 script:
-  - python -m pytest
+  - python tests/*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 numpy
 pytest
 mbuild
-mdtraj
 parmed
 setuptools
 pytest-cookies==0.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+numpy
+pytest
+mbuild
+mdtraj
+parmed
+setuptools
+pytest-cookies==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-import setuptools
+from setuptools import setup
 
-setuptools.setup(
+setup(
         name="mbuild-cookiecutter",
         version="0.0.0",
         description="A Cookiecutter template for creating mBuild recipes",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+setup(
+        name="mbuild-cookiecutter",
+        version="0.0.0",
+        description="A Cookiecutter template for creating mBuild recipes",
+        author="Ray Matsumoto",
+        author_email="ray.a.matsumoto@vanderbilt.edu"
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-import os
-import sys
+import setuptools
 
-setup(
+setuptools.setup(
         name="mbuild-cookiecutter",
         version="0.0.0",
         description="A Cookiecutter template for creating mBuild recipes",

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -1,0 +1,57 @@
+import os
+import re
+import pytest
+
+PATTERN = r"{{(\s?cookiecutter)[.](.*?)}}"
+RE_OBJ = re.compile(PATTERN)
+
+
+@pytest.fixture
+def context():
+    return {
+    "project_name": "my_test_project",
+    "directory_name": "my_test_project",
+    "first_module_name": "first_module",
+    "first_plugin_name": "first_class",
+    "author_name": "Big Chungus",
+    "author_email": "boomer@hotmail.com)",
+    "description": "A short description of the project.",
+    "open_source_license": "MIT"
+    }
+
+
+def build_files_list(root_dir):
+    """Build a list containing absolute paths to the generated files."""
+    return [
+        os.path.join(dirpath, file_path)
+        for dirpath, subdirs, files in os.walk(root_dir)
+        for file_path in files
+    ]
+
+
+def check_paths(paths):
+    """Method to check all paths have correct substitutions,
+    used by other tests cases
+    """
+    # Assert that no match is found in any of the files
+    for path in paths:
+        for line in open(path, "r"):
+            match = RE_OBJ.search(line)
+            msg = "cookiecutter variable not replaced in {}"
+            assert match is None, msg.format(path)
+
+
+def test_project_generation(cookies, context):
+    """
+    Test that project is generated and fully rendered.
+    """
+    result = cookies.bake(extra_context={**context})
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.project.basename == context['project_name']
+    assert result.project.isdir()
+
+    paths = build_files_list(str(result.project))
+    assert paths
+    check_paths(paths)

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -29,18 +29,6 @@ def build_files_list(root_dir):
     ]
 
 
-def check_paths(paths):
-    """Method to check all paths have correct substitutions,
-    used by other tests cases
-    """
-    # Assert that no match is found in any of the files
-    for path in paths:
-        for line in open(path, "r"):
-            match = RE_OBJ.search(line)
-            msg = "cookiecutter variable not replaced in {}"
-            assert match is None, msg.format(path)
-
-
 def test_project_generation(cookies, context):
     """
     Test that project is generated and fully rendered.
@@ -54,4 +42,3 @@ def test_project_generation(cookies, context):
 
     paths = build_files_list(str(result.project))
     assert paths
-    check_paths(paths)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+skipdist = true
+envlist = py36, py37
+
+[testenv]
+deps = requirements-dev.txt
+commands = pytest {posargs:./tests}

--- a/{{cookiecutter.directory_name}}/.travis.yml
+++ b/{{cookiecutter.directory_name}}/.travis.yml
@@ -1,0 +1,25 @@
+language: generic
+
+sudo: false
+
+matrix:
+    include:
+        - {os: linux, env: PYTHON_VERSION=3.6 }
+        - {os: linux, env: PYTHON_VERSION=3.7 }
+        - {os: osx, env: PYTHON_VERSION=3.6 }
+        - {os: osx, env: PYTHON_VERSION=3.7 }
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
+  - source devtools/travis-ci/install.sh
+  - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels omnia
+  - conda config --add channels conda-forge
+  - conda config --add channels mosdef
+  - conda create -n test-environment python=$PYTHON_VERSION --file requirements.txt
+  - source activate test-environment
+  - pip install -e .
+
+script:
+  - python -m pytest

--- a/{{cookiecutter.directory_name}}/requirements-dev.txt
+++ b/{{cookiecutter.directory_name}}/requirements-dev.txt
@@ -1,0 +1,7 @@
+numpy
+pytest
+mbuild
+mdtraj
+parmed
+setuptools
+pytest-cookies==0.4.0

--- a/{{cookiecutter.directory_name}}/requirements.txt
+++ b/{{cookiecutter.directory_name}}/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+pytest
+mbuild
+mdtraj
+parmed
+setuptools


### PR DESCRIPTION
Use `pytest-cookies` to test that the Cookiecutter can successfully be generated.  Right now it seems like the tests have to be called from the main directory.  Not sure if this is an issue yet but want to document this.