### PR TITLE
Change travis badge format to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [//]: # (Badges)
-[![Travis Build Status](https://travis-ci.com/rmatsum836/mbuild-cookiecutter.svg?branch=master)
+[![Build Status](https://travis-ci.com/rmatsum836/mbuild-cookiecutter.svg?branch=master)](https://travis-ci.com/rmatsum836/mbuild-cookiecutter)
 
 # Cookiecutter for mBuild recipes
 


### PR DESCRIPTION
Wasn't paying enough attention before, and had the travis badge in the wrong format.