### PR TITLE
Fix link to miniconda in Travis-CI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Based on the [MolSSI](https://github.com/MolSSI/cookiecutter-cms)
 Cookiecutter.
 
 ## Features
+
 * Pre-configured `setup.py` for installation and packaging which automatically registers with the ``entry_point`` group defined in mBuild
 * Pre-configured Linux and OSX continuous integration on Travis-CI
 * Basic testing with [PyTest](https://docs.pytest.org/en/latest/)

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -3,8 +3,8 @@
 if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then MINICONDA=Miniconda3-latest-MacOSX-x86_64.sh; fi
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then MINICONDA=Miniconda3-latest-Linux-x86_64.sh;  fi
 
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/     *<td>\(.*\)<\/td> */\1/p')
-curl -O https://repo.continuum.io/miniconda/$MINICONDA
+MINICONDA_MD5=$(curl -s https://repo.anaconda.com/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/     *<td>\(.*\)<\/td> */\1/p')
+curl -O https://repo.anaconda.com/miniconda/$MINICONDA
 MD5SUM=$(md5sum $MINICONDA | cut -d ' ' -f 1)
 if [[ $MINICONDA_MD5 !=  $MD5SUM ]]; then
     echo "Miniconda MD5 mismatch"

--- a/mbuild_{{ cookiecutter.project_name.lower().replace(' ', '_') }}/devtools/travis-ci/install.sh
+++ b/mbuild_{{ cookiecutter.project_name.lower().replace(' ', '_') }}/devtools/travis-ci/install.sh
@@ -3,8 +3,8 @@
 if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then MINICONDA=Miniconda3-latest-MacOSX-x86_64.sh; fi
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then MINICONDA=Miniconda3-latest-Linux-x86_64.sh;  fi
 
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/     *<td>\(.*\)<\/td> */\1/p')
-wget https://repo.continuum.io/miniconda/$MINICONDA
+MINICONDA_MD5=$(curl -s https://repo.anaconda.com/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/     *<td>\(.*\)<\/td> */\1/p')
+wget https://repo.anaconda.com/miniconda/$MINICONDA
 MD5SUM=$(md5sum $MINICONDA | cut -d ' ' -f 1)
 if [[ $MINICONDA_MD5 !=  $MD5SUM ]]; then
     echo "Miniconda MD5 mismatch"


### PR DESCRIPTION
The `curl` statement for `https://repo.continuum.io/miniconda` is no longer working so this PR fixes this.  First mentioned in #17 